### PR TITLE
CreateFile2

### DIFF
--- a/kernel33/kernel33.c
+++ b/kernel33/kernel33.c
@@ -163,3 +163,19 @@ WINBASEAPI BOOL GetOverlappedResultEx(
 	ODS_ENTRY();
 	return GetOverlappedResult(hFile, lpOverlapped, lpNumberOfBytesTransferred, (dwMilliseconds == INFINITE));
 }
+
+WINBASEAPI HANDLE CreateFile2(
+	IN    LPCWSTR                          lpFileName, 
+	IN    DWORD                            dwDesiredAccess, 
+	IN    DWORD                            dwShareMode, 
+	IN    DWORD                            dwCreationDisposition, 
+	IN L  PCREATEFILE2_EXTENDED_PARAMETERS pCreateExParams)
+
+{
+   ODS_ENTRY();
+   if(!pCreateExParams)
+     return CreateFileW(lpFileName, dwDesiredAccess, dwShareMode, NULL, dwCreationDisposition, 0, NULL);
+	 
+   return CreateFileW(lpFileName, dwDesiredAccess, dwShareMode, pCreateExParams->lpSecurityAttributes, dwCreationDisposition, pCreateExParams->dwFileAttributes | pCreateExParams->dwFileFlags | pCreateExParams->dwSecurityQosFlags, pCreateExParams->hTemplateFile);
+
+}

--- a/kernel33/kernel33.c
+++ b/kernel33/kernel33.c
@@ -169,7 +169,7 @@ WINBASEAPI HANDLE CreateFile2(
 	IN    DWORD                            dwDesiredAccess, 
 	IN    DWORD                            dwShareMode, 
 	IN    DWORD                            dwCreationDisposition, 
-	IN L  PCREATEFILE2_EXTENDED_PARAMETERS pCreateExParams)
+	IN    PCREATEFILE2_EXTENDED_PARAMETERS pCreateExParams)
 
 {
    ODS_ENTRY();


### PR DESCRIPTION
Added that function because UserBenchmark is starting to ask for it, but it still runs because only a secondary executable needs it.