### PR TITLE
Stubplement *SuspendResumeNotification functions

### DIFF
--- a/user33/user33.c
+++ b/user33/user33.c
@@ -302,6 +302,19 @@ WINUSERAPI BOOL WINAPI PhysicalToLogicalPointForPerMonitorDPI(
 	return PhysicalToLogicalPoint(hWnd, lpPoint);
 }
 
+WINUSERAPI HPOWERNOTIFY WINAPI RegisterSuspendResumeNotification(
+	IN	HANDLE	hRecipient,
+	IN	DWORD	Flags)
+{
+	return NULL;
+}
+
+WINUSERAPI BOOL WINAPI UnregisterSuspendResumeNotification(
+	IN OUT	HPOWERNOTIFY	Handle)
+{
+	return FALSE;
+}
+
 WINUSERAPI HHOOK WINAPI PROXY_FUNCTION(SetWindowsHookExW) (
 	IN	INT			idHook,
 	IN	HOOKPROC	lpfn,

--- a/user33/user33.def
+++ b/user33/user33.def
@@ -23,3 +23,5 @@ EXPORTS
 	SkipPointerFrameMessages
 	LogicalToPhysicalPointForPerMonitorDPI
 	PhysicalToLogicalPointForPerMonitorDPI
+	RegisterSuspendResumeNotification
+	UnregisterSuspendResumeNotification


### PR DESCRIPTION
Required by VMware 16.x

Now vmware-vmx doesn't fail due to unresolved imports, however it fails at version check and version lie doesn't work (maybe related to #9 ).
![Przechwytywanie](https://user-images.githubusercontent.com/32551254/163280537-c735c798-ecae-4db3-9084-c60a1d00746e.PNG)

